### PR TITLE
Fix configuration override bug in GuzzleOauthMeetUp

### DIFF
--- a/GuzzleOauthMeetUp.php
+++ b/GuzzleOauthMeetUp.php
@@ -19,7 +19,8 @@ class GuzzleOauthMeetUp extends BaseConsumerOauth2 {
       'access_token_path' => 'oauth2/access',
       'param_user_id' => 'id',
     );
-    $config = $meetup_config + $config;
+    // Allow user-provided configuration to override defaults.
+    $config = array_merge($meetup_config, $config);
     return parent::factory($config);
   }
 


### PR DESCRIPTION
## Summary
- Allow user configuration options to override GuzzleOauthMeetUp defaults

## Testing
- `php -l GuzzleOauthMeetUp.php`


------
https://chatgpt.com/codex/tasks/task_e_68a74051ba288325902708440e19c36d