### PR TITLE
Use Composer autoloader in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Example code to use Guzzle oAuth with another provider then one of the big four 
 See: http://github.com/VDMi/Guzzle-oAuth
 
 ```php
-// To use the meetup provider, be sure that Guzzle oAuth is in your autoloader
-// This example just includes.. would be better if it was autoloaded.
-include 'GuzzleOauthMeetUp.php';
+// Make sure the Composer autoloader is loaded
+require 'vendor/autoload.php';
 $config = array(
   // see Guzzle oAuth
 );


### PR DESCRIPTION
## Summary
- replace include statement with Composer autoloader in example

## Testing
- `php -l GuzzleOauthMeetUp.php`


------
https://chatgpt.com/codex/tasks/task_e_68a741915b98832597b10741ddc8222b